### PR TITLE
Feature/top level errors

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "lerna": "2.9.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "independent"
+  "version": "0.6.1"
 }

--- a/packages/parcels-docs/src/examples/04-forms.jsx
+++ b/packages/parcels-docs/src/examples/04-forms.jsx
@@ -46,6 +46,9 @@ export default class ExampleMeta extends React.Component {
                 onSubmit: (value) => {
                     console.log("submitted:", value);
                 },
+                onError: (errors) => {
+                    console.log("errors", errors);
+                },
                 validators: {
                     "name": [isRequired],
                     "email": [isRequired, isEmail],
@@ -61,6 +64,8 @@ export default class ExampleMeta extends React.Component {
                 return <p className="Text Text-failure Text-margin">{error}</p>;
             }
         };
+
+        // TODO - does initialMeta() work together with forms?
 
         return example(this, desc, <div>
 

--- a/packages/parcels-plugin-form/src/ParcelsPluginForm.js
+++ b/packages/parcels-plugin-form/src/ParcelsPluginForm.js
@@ -14,11 +14,12 @@ type ParcelsPluginFormConfig = {
 export default (config: ParcelsPluginFormConfig = {}): Function => {
     let {
         onSubmit,
+        onError,
         validators
     } = config;
 
     return pipe(
-        SubmitModifier(onSubmit),
+        SubmitModifier({onSubmit, onError}),
         TouchedModifier(),
         DirtyModifier(),
         ValidModifier(validators)


### PR DESCRIPTION
- Allow `parcels-plugin-form/SubmitModifier` to store last captured errors on `meta.errors`
- Allow `parcels-plugin-form/SubmitModifier` to call `onError` when validation fails
- Begin version locking packages