### PR TITLE
Parcel.modifyChangeValue()

### DIFF
--- a/packages/parcels/src/change/Action.js
+++ b/packages/parcels/src/change/Action.js
@@ -34,6 +34,14 @@ export default class Action {
         return this.type === "ping";
     };
 
+    isValueAction = (): boolean => {
+        return this.type !== "ping" && this.type !== "setMeta";
+    };
+
+    isMetaAction = (): boolean => {
+        return this.type === "setMeta";
+    };
+
     toJS = (): ActionData => {
         let {type, payload, keyPath} = this;
         return {type, payload, keyPath};

--- a/packages/parcels/src/change/__test__/Action-test.js
+++ b/packages/parcels/src/change/__test__/Action-test.js
@@ -52,3 +52,15 @@ test('Action should unshift key to front of keyPath when ungetting', tt => {
 
     tt.deepEqual(expectedAction, new Action(action)._unget('b').toJS());
 });
+
+test('Action should be value action if it isnt ping or setMeta', tt => {
+    tt.false(new Action({type: "ping"}).isValueAction());
+    tt.true(new Action({type: "set"}).isValueAction());
+    tt.false(new Action({type: "setMeta"}).isValueAction());
+});
+
+test('Action should be meta action if it is setMeta', tt => {
+    tt.false(new Action({type: "ping"}).isMetaAction());
+    tt.false(new Action({type: "set"}).isMetaAction());
+    tt.true(new Action({type: "setMeta"}).isMetaAction());
+});

--- a/packages/parcels/src/parcel/ModifyMethods.js
+++ b/packages/parcels/src/parcel/ModifyMethods.js
@@ -75,6 +75,20 @@ export default (_this: Parcel): Object => ({
         );
     },
 
+    modifyChangeValue: (updater: Function): Parcel => {
+        return _this.modifyChange((parcel: Parcel, changeRequest: ChangeRequest) => {
+
+            let valueActionFilter = actions => actions.filter(action => !action.isValueAction());
+            parcel.dispatch(changeRequest.updateActions(valueActionFilter));
+
+            pipeWith(
+                changeRequest.data().value,
+                updater,
+                parcel.onChange
+            );
+        });
+    },
+
     initialMeta: (initialMeta: Object = {}): Parcel => {
         let {meta} = _this._parcelData;
 

--- a/packages/parcels/src/parcel/Parcel.js
+++ b/packages/parcels/src/parcel/Parcel.js
@@ -144,6 +144,7 @@ export default class Parcel {
     modifyData: Function;
     modifyValue: Function;
     modifyChange: Function;
+    modifyChangeValue: Function;
     initialMeta: Function;
     addPreModifier: Function;
     addModifier: Function;

--- a/packages/parcels/src/parcel/__test__/ModifyMethods-test.js
+++ b/packages/parcels/src/parcel/__test__/ModifyMethods-test.js
@@ -85,6 +85,61 @@ test('Parcel.modifyChange() should allow you to change the payload of a changed 
         .onChange(456);
 });
 
+test('Parcel.modifyChange() should allow you to stop a change by not calling dispatch', (tt: Object) => {
+    var data = {
+        value: 123,
+        handleChange: (parcel: Parcel) => {
+            tt.fail('modifyChange() with no changes in it should NOT call handle change, but it has');
+        }
+    };
+
+    new Parcel(data)
+        .modifyChange((parcel: Parcel, changeRequest: ChangeRequest) => {
+            // nothing here, run a passing assertion to make this test valid
+            tt.true(true);
+        })
+        .onChange(456);
+});
+
+test('Parcel.modifyChangeValue() should allow you to change the payload of a changed parcel with an updater', (tt: Object) => {
+    tt.plan(1);
+
+    var data = {
+        value: 123,
+        handleChange: (parcel: Parcel) => {
+            let {value} = parcel.data();
+            tt.is(457, value, "original handleChange should receive updated value");
+        }
+    };
+
+    new Parcel(data)
+        .modifyChangeValue(value => value + 1)
+        .onChange(456);
+});
+
+test('Parcel.modifyChangeValue() should allow changes to meta through', (tt: Object) => {
+    tt.plan(2);
+
+    var data = {
+        value: 123,
+        handleChange: (parcel: Parcel) => {
+            let {value, meta} = parcel.data();
+            tt.is(457, value, "original handleChange should receive updated value");
+            tt.deepEqual({abc: 123}, meta, "original handleChange should receive updated meta");
+        }
+    };
+
+    new Parcel(data)
+        .modifyChangeValue(value => value + 1)
+        .batch(parcel => {
+            parcel.onChange(456);
+            parcel.setMeta({
+                abc: 123
+            });
+        });
+});
+
+
 test('Parcel.initialMeta() should work', (tt: Object) => {
     tt.plan(3);
 


### PR DESCRIPTION
- Added `Action.isValueAction()` and `Action.isMetaAction()`
- Added `Parcel.modifyChangeValue()`. It accepts a function that updates the value in the current change request.

Addresses #46 