### PR TITLE
Change request meta

### DIFF
--- a/packages/parcels-plugin-form/src/SubmitModifier.js
+++ b/packages/parcels-plugin-form/src/SubmitModifier.js
@@ -7,35 +7,32 @@ export default ({onSubmit, onError}: Object) => (parcel: Parcel): Parcel => {
     let newParcel = parcel
         .initialMeta({
             attemptedSubmit: false,
-            submitting: false, // TODO - actionMeta can replace this
             submit: () => ref.submit()
         })
         .modifyChange((parcel: Parcel, changeRequest: ChangeRequest) => {
             let parcelData = changeRequest.data();
-            let {submitting, errors} = parcelData.meta;
+            let {fromSubmit} = changeRequest.meta();
+            let {errors} = parcelData.meta;
 
-            if(!submitting) { // TODO - actionMeta can replace this
-                parcel.dispatch(changeRequest);
-                return;
-            }
-
-            if(errors && errors.length > 0) {
-                onError && onError(errors, parcelData);
-            } else {
-                onSubmit && onSubmit(parcelData.value, parcelData);
+            if(fromSubmit) {
+                if(errors && errors.length > 0) {
+                    onError && onError(errors, parcelData);
+                } else {
+                    onSubmit && onSubmit(parcelData.value, parcelData);
+                }
             }
 
             parcel.dispatch(changeRequest);
-            parcel.setMeta({ // TODO - actionMeta can replace this
-                submitting: false
-            });
         });
 
     ref.submit = () => {
         newParcel.batch((parcel: Parcel) => {
             parcel.setMeta({
-                attemptedSubmit: true,
-                submitting: true
+                attemptedSubmit: true
+            });
+
+            parcel.setChangeRequestMeta({
+                fromSubmit: true
             });
 
             let {validate} = parcel.getInternalLocationShareData();

--- a/packages/parcels/src/change/ChangeRequest.js
+++ b/packages/parcels/src/change/ChangeRequest.js
@@ -67,7 +67,9 @@ export default class ChangeRequest {
     };
 
     merge = (other: ChangeRequest): ChangeRequest => {
-        return this.updateActions(ii => ii.concat(other.actions()));
+        return this
+            .updateActions(ii => ii.concat(other.actions()))
+            .setMeta(other.meta());
     };
 
     meta = (): * => {

--- a/packages/parcels/src/parcel/Parcel.js
+++ b/packages/parcels/src/parcel/Parcel.js
@@ -109,6 +109,7 @@ export default class Parcel {
     onChangeDOM: Function;
     setMeta: Function;
     updateMeta: Function;
+    setChangeRequestMeta: Function;
     ping: Function;
     // - parent parcel methods
     set: Function;

--- a/packages/parcels/src/parcel/ValueParcelMethods.js
+++ b/packages/parcels/src/parcel/ValueParcelMethods.js
@@ -2,6 +2,7 @@
 import type {ParcelData} from '../types/Types';
 import type Parcel from './Parcel';
 import strip from '../parcelData/strip';
+import ChangeRequest from '../change/ChangeRequest';
 import ActionCreators from '../change/ActionCreators';
 import {containsWildcard, split} from '../modifiers/Matcher';
 
@@ -125,6 +126,10 @@ export default (_this: Parcel): Object => ({
     updateMeta: (updater: Function) => {
         let {meta} = _this._parcelData;
         _this.setMeta(updater(meta));
+    },
+
+    setChangeRequestMeta: (partialMeta: Object) => {
+        _this.dispatch(new ChangeRequest().setMeta(partialMeta));
     },
 
     ping: () => {

--- a/packages/parcels/src/parcel/__test__/ValueParcelMethods-test.js
+++ b/packages/parcels/src/parcel/__test__/ValueParcelMethods-test.js
@@ -388,6 +388,22 @@ test('Parcel.updateMeta() should call the Parcels handleChange function with the
     });
 });
 
+test('Parcel.setChangeRequestMeta() should set change request meta', (tt: Object) => {
+    var data = {
+        value: 123,
+        handleChange: (parcel, changeRequest) => {
+            tt.deepEqual({a: 3, b: 2}, changeRequest.meta());
+        }
+    };
+
+    var parcel = new Parcel(data).batch(parcel => {
+        parcel.setChangeRequestMeta({a: 1});
+        parcel.onChange(456);
+        parcel.setChangeRequestMeta({b: 2});
+        parcel.setChangeRequestMeta({a: 3});
+    });
+});
+
 test('Parcel.equals() should compare two parcels data', (tt: Object) => {
     var child = {};
     var parcelCreator = (merge = {}) => {


### PR DESCRIPTION
- `ChangeRequest.merge()` now also merges change request meta
- Added `Parcel. setChangeRequestMeta()`. This sets `meta` on the change request. You'll almost certainly use this inside a `Parcel.batch()`
- `SubmitModifier` now makes use of change request meta