### PR TITLE
Feature/change request improvements

### DIFF
--- a/packages/parcels/src/change/ChangeRequest.js
+++ b/packages/parcels/src/change/ChangeRequest.js
@@ -93,6 +93,14 @@ export default class ChangeRequest {
         });
     };
 
+    originId = (): ?string => {
+        return this._originId;
+    };
+
+    originPath = (): ?string[] => {
+        return this._originPath;
+    };
+
     toJS = (): Object => {
         return {
             actions: this._actions,

--- a/packages/parcels/src/change/ChangeRequest.js
+++ b/packages/parcels/src/change/ChangeRequest.js
@@ -69,14 +69,14 @@ export default class ChangeRequest {
     merge = (other: ChangeRequest): ChangeRequest => {
         return this
             .updateActions(ii => ii.concat(other.actions()))
-            .setMeta(other.meta());
+            .setChangeRequestMeta(other.changeRequestMeta());
     };
 
-    meta = (): * => {
+    changeRequestMeta = (): * => {
         return this._meta;
     };
 
-    setMeta = (partialMeta: *): ChangeRequest => {
+    setChangeRequestMeta = (partialMeta: *): ChangeRequest => {
         return this._create({
             meta: {
                 ...this._meta,

--- a/packages/parcels/src/change/ChangeRequest.js
+++ b/packages/parcels/src/change/ChangeRequest.js
@@ -56,6 +56,14 @@ export default class ChangeRequest {
         return Reducer(parcelDataFromRegistry, this._actions);
     };
 
+    value = (): * => {
+        return this.data().value;
+    };
+
+    meta = (): * => {
+        return this.data().meta;
+    };
+
     actions = (): Action[] => {
         return this._actions;
     };

--- a/packages/parcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/parcels/src/change/__test__/ChangeRequest-test.js
@@ -161,3 +161,55 @@ test('ChangeRequest data() should get latest parcel data from treeshare when cal
 test('ChangeRequest should throw error if data() is called before setBaseParcel()', tt => {
     tt.is(tt.throws(() => new ChangeRequest().data(), Error).message, `ChangeRequest data() cannot be called before calling setBaseParcel()`);
 });
+
+test('ChangeRequest value() should be a shortcut for data().value', tt => {
+    var action = new Action({
+        type: "set",
+        keyPath: ["b"],
+        payload: {
+            value: 3
+        }
+    });
+
+    var parcel = new Parcel({
+        value: {
+            a: 1,
+            b: 2
+        }
+    });
+
+    let value = new ChangeRequest(action)
+        .setBaseParcel(parcel)
+        .value();
+
+    var expectedValue = {
+        a: 1,
+        b: 3
+    };
+
+    tt.deepEqual(expectedValue, value);
+});
+
+test('ChangeRequest meta() should be a shortcut for data().meta', tt => {
+    var action = new Action({
+        type: "setMeta",
+        payload: {
+            meta: {
+                abc: 123
+            }
+        }
+    });
+
+    var parcel = new Parcel();
+
+    let meta = new ChangeRequest(action)
+        .setBaseParcel(parcel)
+        .meta();
+
+    var expectedMeta = {
+        abc: 123
+    };
+
+    tt.deepEqual(expectedMeta, meta);
+});
+

--- a/packages/parcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/parcels/src/change/__test__/ChangeRequest-test.js
@@ -60,7 +60,7 @@ test('ChangeRequest merge() should merge other change requests actions', tt => {
 });
 
 
-test('ChangeRequest setMeta() and meta() should work', tt => {
+test('ChangeRequest setChangeRequestMeta() and changeRequestMeta() should work', tt => {
     let expectedMeta = {
         a: 3,
         b: 2
@@ -68,10 +68,10 @@ test('ChangeRequest setMeta() and meta() should work', tt => {
     tt.deepEqual(
         expectedMeta,
         new ChangeRequest()
-            .setMeta({a: 1})
-            .setMeta({b: 2})
-            .setMeta({a: 3})
-            .meta()
+            .setChangeRequestMeta({a: 1})
+            .setChangeRequestMeta({b: 2})
+            .setChangeRequestMeta({a: 3})
+            .changeRequestMeta()
     );
 });
 

--- a/packages/parcels/src/change/__test__/ChangeRequest-test.js
+++ b/packages/parcels/src/change/__test__/ChangeRequest-test.js
@@ -213,3 +213,45 @@ test('ChangeRequest meta() should be a shortcut for data().meta', tt => {
     tt.deepEqual(expectedMeta, meta);
 });
 
+test('ChangeRequest should keep originId and originPath', (tt: Object) => {
+    tt.plan(2);
+
+    var data = {
+        value: {
+            abc: 123
+        },
+        handleChange: (parcel: Parcel, changeRequest: ChangeRequest) => {
+            tt.deepEqual(['abc'], changeRequest.originPath());
+            tt.deepEqual('^.abc', changeRequest.originId());
+        }
+    };
+
+    new Parcel(data)
+        .get('abc')
+        .onChange(456);
+        //.modifyChangeValue(value => value + 1)
+});
+
+
+test('ChangeRequest should keep originId and originPath even when going through a batch() where another change is fired before the original one', (tt: Object) => {
+    tt.plan(2);
+
+    var data = {
+        value: {
+            abc: 123,
+            def: 456
+        },
+        handleChange: (parcel: Parcel, changeRequest: ChangeRequest) => {
+            tt.deepEqual(['abc'], changeRequest.originPath());
+            tt.deepEqual('^.~mc.abc', changeRequest.originId());
+        }
+    };
+
+    new Parcel(data)
+        .modifyChange((parcel, changeRequest) => {
+            parcel.set('def', 789);
+            parcel.dispatch(changeRequest);
+        })
+        .get('abc')
+        .onChange(456);
+});

--- a/packages/parcels/src/parcel/ValueParcelMethods.js
+++ b/packages/parcels/src/parcel/ValueParcelMethods.js
@@ -88,7 +88,7 @@ export default (_this: Parcel): Object => ({
 
     setChangeRequestMeta: (partialMeta: Object) => {
         Types(`setChangeRequestMeta() expects param "partialMeta" to be`, `object`)(partialMeta);
-        _this.dispatch(new ChangeRequest().setMeta(partialMeta));
+        _this.dispatch(new ChangeRequest().setChangeRequestMeta(partialMeta));
     },
 
     ping: () => {

--- a/packages/parcels/src/parcel/__test__/ValueParcelMethods-test.js
+++ b/packages/parcels/src/parcel/__test__/ValueParcelMethods-test.js
@@ -392,7 +392,7 @@ test('Parcel.setChangeRequestMeta() should set change request meta', (tt: Object
     var data = {
         value: 123,
         handleChange: (parcel, changeRequest) => {
-            tt.deepEqual({a: 3, b: 2}, changeRequest.meta());
+            tt.deepEqual({a: 3, b: 2}, changeRequest.changeRequestMeta());
         }
     };
 

--- a/packages/parcels/src/types/Types.js
+++ b/packages/parcels/src/types/Types.js
@@ -6,6 +6,7 @@ import type Treeshare from '../treeshare/Treeshare';
 import Parcel from '../parcel/Parcel';
 import Action from '../change/Action';
 import ChangeRequest from '../change/ChangeRequest';
+import isPlainObject from 'unmutable/lib/util/isPlainObject';
 
 export type ParcelData = {
     value?: *,
@@ -109,7 +110,7 @@ const runtimeTypes = {
     },
     ['parcelData']: {
         name: "an object containing parcel data {value: *, meta?: {}, key?: *}",
-        check: ii => typeof ii === "object" && ii.hasOwnProperty('value') && !(ii instanceof Parcel)
+        check: ii => isPlainObject(ii) && ii.hasOwnProperty('value')
     },
     ['string']: {
         name: "a string",


### PR DESCRIPTION
- Add `ChangeRequest.originId()`
- Add `ChangeRequest.originPath()`
- Rename `ChangeRequest.meta()` to `ChangeRequest.changeRequestMeta()`
- Rename `ChangeRequest.setMeta()` to `ChangeRequest.setChangeRequestMeta()`
- Add `ChangeRequest.value()` to get `value` from `ChangeRequest.data()` 
- Add `ChangeRequest.meta()` to get `meta` from `ChangeRequest.data()` 

Addresses #53 

Sequential calls to `ChangeRequest.data()`, `ChangeRequest.meta()` and `ChangeRequest.value()` will be a bit slow because they are calculated fresh each time by running all the actions through the reducer. Perf gains will happen in https://github.com/blueflag/parcels/issues/56