### PR TITLE
Artistic Antelope

### DIFF
--- a/packages/parcels-react/src/ParcelStateHock.jsx
+++ b/packages/parcels-react/src/ParcelStateHock.jsx
@@ -12,7 +12,7 @@ type ChildProps = {};
 type ParcelStateHockConfig = {
     debugRender?: boolean,
     initialValue?: (props: Object) => *,
-    modify?: (parcel: Parcel) => Parcel,
+    modify?: (props: Object) => (parcel: Parcel) => Parcel,
     prop: string
 };
 
@@ -22,7 +22,7 @@ export default (config: ParcelStateHockConfig): Function => {
     let {
         initialValue = () => undefined,
         prop,
-        modify = ii => ii,
+        modify = props => ii => ii, /* eslint-disable-line no-unused-vars */
         debugRender = false
     } = config;
 
@@ -50,7 +50,10 @@ export default (config: ParcelStateHockConfig): Function => {
         render(): Node {
             let {parcel} = this.state;
             if(modify) {
-                parcel = parcel.modify(modify);
+                let modifyWithProps = modify(this.props);
+                Types(`ParcelStateHock() expects param "config.modify" to return`, `function`)(modifyWithProps);
+                parcel = modifyWithProps(parcel);
+                Types(`ParcelStateHock() expects param "config.modify(props)" to return`, `parcel`)(parcel);
             }
 
             let props = {

--- a/packages/parcels-react/src/__test__/ParcelStateHock-test.js
+++ b/packages/parcels-react/src/__test__/ParcelStateHock-test.js
@@ -59,13 +59,14 @@ test('ParcelStateHock changes should be put back into ParcelStateHock state', tt
 
 
 test('ParcelStateHock config should accept a modify function', tt => {
-    tt.plan(2);
+    tt.plan(3);
     CheckHockChildProps(
         ParcelStateHock({
             initialValue: () => 456,
             prop: "proppy",
-            modify: (parcel) => {
+            modify: (props) => (parcel) => {
                 tt.is(456, parcel.value(), `modify should receive parcel`);
+                tt.deepEqual({}, props, `modify should receive props`);
                 return parcel.modifyValue(ii => ii + 1);
             }
         }),

--- a/packages/parcels/src/change/ChangeRequest.js
+++ b/packages/parcels/src/change/ChangeRequest.js
@@ -56,6 +56,14 @@ export default class ChangeRequest {
         return Reducer(parcelDataFromRegistry, this._actions);
     };
 
+    value = (): * => {
+        return this.data().value;
+    };
+
+    meta = (): * => {
+        return this.data().meta;
+    };
+
     actions = (): Action[] => {
         return this._actions;
     };
@@ -69,20 +77,28 @@ export default class ChangeRequest {
     merge = (other: ChangeRequest): ChangeRequest => {
         return this
             .updateActions(ii => ii.concat(other.actions()))
-            .setMeta(other.meta());
+            .setChangeRequestMeta(other.changeRequestMeta());
     };
 
-    meta = (): * => {
+    changeRequestMeta = (): * => {
         return this._meta;
     };
 
-    setMeta = (partialMeta: *): ChangeRequest => {
+    setChangeRequestMeta = (partialMeta: *): ChangeRequest => {
         return this._create({
             meta: {
                 ...this._meta,
                 ...partialMeta
             }
         });
+    };
+
+    originId = (): ?string => {
+        return this._originId;
+    };
+
+    originPath = (): ?string[] => {
+        return this._originPath;
     };
 
     toJS = (): Object => {

--- a/packages/parcels/src/parcel/ValueParcelMethods.js
+++ b/packages/parcels/src/parcel/ValueParcelMethods.js
@@ -88,7 +88,7 @@ export default (_this: Parcel): Object => ({
 
     setChangeRequestMeta: (partialMeta: Object) => {
         Types(`setChangeRequestMeta() expects param "partialMeta" to be`, `object`)(partialMeta);
-        _this.dispatch(new ChangeRequest().setMeta(partialMeta));
+        _this.dispatch(new ChangeRequest().setChangeRequestMeta(partialMeta));
     },
 
     ping: () => {

--- a/packages/parcels/src/parcel/__test__/ValueParcelMethods-test.js
+++ b/packages/parcels/src/parcel/__test__/ValueParcelMethods-test.js
@@ -392,7 +392,7 @@ test('Parcel.setChangeRequestMeta() should set change request meta', (tt: Object
     var data = {
         value: 123,
         handleChange: (parcel, changeRequest) => {
-            tt.deepEqual({a: 3, b: 2}, changeRequest.meta());
+            tt.deepEqual({a: 3, b: 2}, changeRequest.changeRequestMeta());
         }
     };
 

--- a/packages/parcels/src/types/Types.js
+++ b/packages/parcels/src/types/Types.js
@@ -6,6 +6,7 @@ import type Treeshare from '../treeshare/Treeshare';
 import Parcel from '../parcel/Parcel';
 import Action from '../change/Action';
 import ChangeRequest from '../change/ChangeRequest';
+import isPlainObject from 'unmutable/lib/util/isPlainObject';
 
 export type ParcelData = {
     value?: *,
@@ -109,7 +110,7 @@ const runtimeTypes = {
     },
     ['parcelData']: {
         name: "an object containing parcel data {value: *, meta?: {}, key?: *}",
-        check: ii => typeof ii === "object" && ii.hasOwnProperty('value') && !(ii instanceof Parcel)
+        check: ii => isPlainObject(ii) && ii.hasOwnProperty('value')
     },
     ['string']: {
         name: "a string",

--- a/packages/parcels/src/types/Types.js
+++ b/packages/parcels/src/types/Types.js
@@ -71,7 +71,7 @@ const runtimeTypes = {
         check: ii => typeof ii === "function"
     },
     ['functionArray']: {
-        name: "",
+        name: "functions",
         check: ii => ii
             && Array.isArray(ii)
             && ii.every(jj => typeof jj === "function")


### PR DESCRIPTION
### parcels

#### Change Request Improvements

- Added `ChangeRequest.originId()`. This returns the id of the parcel that started the change.
- Added `ChangeRequest.originPath()`. This returns the path of the parcel that started the change.
- **BREAKING CHANGE** Renamed `ChangeRequest.meta()` to `ChangeRequest.changeRequestMeta()`
- **BREAKING CHANGE** Renamed `ChangeRequest.setMeta()` to `ChangeRequest.setChangeRequestMeta()`
- Added `ChangeRequest.value()` to get `value` from `ChangeRequest.data()` 
- **BREAKING CHANGE** Changed `ChangeRequest.meta()` to get `meta` from `ChangeRequest.data()`

#### Minor fixes

- Fix missing name in type checkers

Addresses #53 

Sequential calls to `ChangeRequest.data()`, `ChangeRequest.meta()` and `ChangeRequest.value()` will be a bit slow because they are calculated fresh each time by running all the actions through the reducer. Perf gains will happen in https://github.com/blueflag/parcels/issues/56

### parcels-react

- **BREAKING CHANGE** `ParcelStateHock` config variable `modify` now passes `props` and `parcels` using partially applied functions:
  - Old: `ParcelStateHock({modify: (parcel) => parcel, ... })`
  - New: `ParcelStateHock({modify: (props) => (parcel) => parcel, ... })`

### parcels-plugin-form

- No change