### PR TITLE
Feature/parcelstatehock modify

### DIFF
--- a/packages/parcels-react/src/ParcelStateHock.jsx
+++ b/packages/parcels-react/src/ParcelStateHock.jsx
@@ -12,7 +12,7 @@ type ChildProps = {};
 type ParcelStateHockConfig = {
     debugRender?: boolean,
     initialValue?: (props: Object) => *,
-    modify?: (parcel: Parcel) => Parcel,
+    modify?: (props: Object) => (parcel: Parcel) => Parcel,
     prop: string
 };
 
@@ -22,7 +22,7 @@ export default (config: ParcelStateHockConfig): Function => {
     let {
         initialValue = () => undefined,
         prop,
-        modify = ii => ii,
+        modify = props => ii => ii, /* eslint-disable-line no-unused-vars */
         debugRender = false
     } = config;
 
@@ -50,7 +50,10 @@ export default (config: ParcelStateHockConfig): Function => {
         render(): Node {
             let {parcel} = this.state;
             if(modify) {
-                parcel = parcel.modify(modify);
+                let modifyWithProps = modify(this.props);
+                Types(`ParcelStateHock() expects param "config.modify" to return`, `function`)(modifyWithProps);
+                parcel = modifyWithProps(parcel);
+                Types(`ParcelStateHock() expects param "config.modify(props)" to return`, `parcel`)(parcel);
             }
 
             let props = {

--- a/packages/parcels-react/src/__test__/ParcelStateHock-test.js
+++ b/packages/parcels-react/src/__test__/ParcelStateHock-test.js
@@ -59,13 +59,14 @@ test('ParcelStateHock changes should be put back into ParcelStateHock state', tt
 
 
 test('ParcelStateHock config should accept a modify function', tt => {
-    tt.plan(2);
+    tt.plan(3);
     CheckHockChildProps(
         ParcelStateHock({
             initialValue: () => 456,
             prop: "proppy",
-            modify: (parcel) => {
+            modify: (props) => (parcel) => {
                 tt.is(456, parcel.value(), `modify should receive parcel`);
+                tt.deepEqual({}, props, `modify should receive props`);
                 return parcel.modifyValue(ii => ii + 1);
             }
         }),

--- a/packages/parcels/src/types/Types.js
+++ b/packages/parcels/src/types/Types.js
@@ -71,7 +71,7 @@ const runtimeTypes = {
         check: ii => typeof ii === "function"
     },
     ['functionArray']: {
-        name: "",
+        name: "functions",
         check: ii => ii
             && Array.isArray(ii)
             && ii.every(jj => typeof jj === "function")


### PR DESCRIPTION
### parcels

- Fix missing name in type checkers
- No breaking changes

### parcels-react

- **BREAKING CHANGE** `ParcelStateHock` config variable `modify` now passes `props` and `parcels` using partially applied functions:
  - Old: `ParcelStateHock({modify: (parcel) => parcel, ... })`
  - New: `ParcelStateHock({modify: (props) => (parcel) => parcel, ... })`

### parcels-plugin-form

- No change